### PR TITLE
adapter.http: implement submodel repo routes

### DIFF
--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -143,7 +143,7 @@ class XmlResponse(APIResponse):
                 response_elem = object_to_xml_element(obj)
                 parent.append(response_elem)
                 etree.cleanup_namespaces(parent)
-        return etree.tostring(response_elem, xml_declaration=True, encoding=BASE64URL_ENCODING)
+        return etree.tostring(response_elem, xml_declaration=True, encoding="utf-8")
 
 
 class XmlResponseAlt(XmlResponse):

--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -727,7 +727,8 @@ class WSGIApp:
             if semantic_id is not None:
                 spec_semantic_id = HTTPApiDecoder.base64json(semantic_id, model.Reference, False)
                 submodels = filter(lambda sm: sm.semantic_id == spec_semantic_id, submodels)
-        references: Iterator[model.ModelReference] = [model.ModelReference.from_referable(submodel) for submodel in submodels]
+        references: list[model.ModelReference] = [model.ModelReference.from_referable(submodel)
+                                                  for submodel in submodels]
         return response_t(list(references), stripped=is_stripped_request(request))
 
     # --------- SUBMODEL ROUTES ---------
@@ -788,8 +789,8 @@ class WSGIApp:
         response_t = get_response_type(request)
         submodel = self._get_obj_ts(url_args["submodel_id"], model.Submodel)
         submodel.update()
-        references: Iterator[model.ModelReference] = [model.ModelReference.from_referable(element) for element in
-                                                      submodel.submodel_element]
+        references: list[model.ModelReference] = [model.ModelReference.from_referable(element) for element in
+                                                  submodel.submodel_element]
         return response_t(list(references), stripped=is_stripped_request(request))
 
     def get_submodel_submodel_elements_id_short_path(self, request: Request, url_args: Dict, **_kwargs) -> Response:
@@ -809,7 +810,8 @@ class WSGIApp:
         submodel_element = self._get_nested_submodel_element(submodel, url_args["id_shorts"])
         return response_t(submodel_element, stripped=True)
 
-    def get_submodel_submodel_elements_id_short_path_reference(self, request: Request, url_args: Dict, **_kwargs) -> Response:
+    def get_submodel_submodel_elements_id_short_path_reference(self, request: Request, url_args: Dict, **_kwargs)\
+            -> Response:
         # TODO: support content, extent parameters
         response_t = get_response_type(request)
         submodel = self._get_obj_ts(url_args["submodel_id"], model.Submodel)

--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -662,7 +662,7 @@ class WSGIApp:
 
     def delete_submodel(self, request: Request, url_args: Dict, **_kwargs) -> Response:
         response_t = get_response_type(request)
-        self.object_store.remove(self._get_obj_ts(url_args["aas_id"], model.Submodel))
+        self.object_store.remove(self._get_obj_ts(url_args["submodel_id"], model.Submodel))
         return response_t()
 
     # --------- SUBMODEL ROUTES ---------

--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -823,7 +823,7 @@ class WSGIApp:
                                                            is_stripped_request(request))
         try:
             parent.add_referable(new_submodel_element)
-        except KeyError:
+        except model.AASConstraintViolation:
             raise Conflict(f"SubmodelElement with idShort {new_submodel_element.id_short} already exists "
                            f"within {parent}!")
         created_resource_url = map_adapter.build(self.get_submodel_submodel_elements_id_short_path, {


### PR DESCRIPTION
Adds URl-Base64 decoding, semanticId filtering and the level specification in the API (core/deep).
Also adds all metadata and reference routes.