### PR TITLE
adapter.http: fix a `DeprecationWarning`

### DIFF
--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -54,7 +54,7 @@ class Message:
         self.code: str = code
         self.text: str = text
         self.message_type: MessageType = message_type
-        self.timestamp: datetime.datetime = timestamp if timestamp is not None else datetime.datetime.utcnow()
+        self.timestamp: datetime.datetime = timestamp if timestamp is not None else datetime.datetime.now(datetime.UTC)
 
 
 class Result:


### PR DESCRIPTION
```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)
```