### PR TITLE
adapter.http: remove nonfunctional 'Not Implemented' check

### DIFF
--- a/basyx/aas/adapter/http.py
+++ b/basyx/aas/adapter/http.py
@@ -699,8 +699,6 @@ class WSGIApp:
         map_adapter: MapAdapter = self.url_map.bind_to_environ(request.environ)
         try:
             endpoint, values = map_adapter.match()
-            if endpoint is None:
-                raise werkzeug.exceptions.NotImplemented("This route is not yet implemented.")
             # TODO: remove this 'type: ignore' comment once the werkzeug type annotations have been fixed
             #  https://github.com/pallets/werkzeug/issues/2836
             return endpoint(request, values, map_adapter=map_adapter)  # type: ignore[operator]


### PR DESCRIPTION
This check was intended to return 501 instead of 404 for routes that haven't been implemented. However, we explicitly implement these routes to return 501 now anyway, returning 501 for all other paths would be semantically incorrect anyway and the check never worked.