### PR TITLE
Move `update()` and `commit()` functions to `AbstractObjectStore`

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -414,7 +414,7 @@ class AASXWriter:
                                  str(semantic_id), e.value)
                     continue
                 concept_descriptions.append(cd)
-        objects_to_be_written.update(concept_descriptions)
+        objects_to_be_written.add_from(concept_descriptions)
 
         # Write AAS data part
         self.write_all_aas_objects("/aasx/data.{}".format("json" if write_json else "xml"),

--- a/basyx/aas/backend/backends.py
+++ b/basyx/aas/backend/backends.py
@@ -4,21 +4,27 @@
 # the LICENSE file of this project.
 #
 # SPDX-License-Identifier: MIT
-"""
-This module provides a registry and and abstract base class for Backends. A :class:`~.Backend` is a class that allows to
-synchronize Referable AAS objects or their included data with external data sources such as a remote API or a local
-source for real time data. Each backend provides access to one kind of data source.
+"""This module provides a registry and abstract base class for
+Backends. A :class:`~.Backend` is a class that allows to synchronize
+Referable AAS objects or their included data with external data
+sources such as a remote API or a local source for real time data.
+Each backend provides access to one kind of data source.
 
-The data source of an individual object is specified as an URI in its ``source`` attribute. The schema part of that URI
-defines the type of data source and, in consequence, the backend class to use for synchronizing this object.
+The data source of an individual object is specified as a URI in its
+``source`` attribute. The schema part of that URI defines the type of
+data source and, in consequence, the backend class to use for
+synchronizing this object.
 
-Custom backends for additional types of data sources can be implemented by subclassing :class:`Backend` and
-implementing the :meth:`~.Backend.commit_object` and :meth:`~.Backend.update_object` class methods. These are used
-internally by the objects' :meth:`~basyx.aas.model.base.Referable.update` and
-:meth:`~basyx.aas.model.base.Referable.commit` methods when the backend is applicable for the relevant source URI.
-Then, the Backend class needs to be registered to handle update/commit requests for a specific URI schema, using
-:meth:`~basyx.aas.backend.backends.register_backend`.
-"""
+Custom backends for additional types of data sources can be
+implemented by subclassing :class:`Backend` and implementing the
+:meth:`~.Backend.commit_object` and :meth:`~.Backend.update_object`
+class methods. These are used internally by the objects'
+:meth:`~basyx.aas.model.provider.DictObjectStore.update` and
+:meth:`~basyx.aas.model.provider.DictObjectStore.commit` methods when
+the backend is applicable for the relevant source URI. Then,
+the Backend class needs to be registered to handle update/commit
+requests for a specific URI schema, using
+:meth:`~basyx.aas.backend.backends.register_backend`."""
 import abc
 import re
 from typing import List, Dict, Type, TYPE_CHECKING
@@ -31,10 +37,14 @@ class Backend(metaclass=abc.ABCMeta):
     """
     Abstract base class for all Backend classes.
 
-    Each Backend class is typically capable of synchronizing (updating/committing) objects with a type of external data
-    source, identified by one or more source URI schemas. Custom backends for custom source URI schemas should inherit
-    from this class and be registered via :meth:`~basyx.aas.backend.backends.register_backend`. to be used by Referable
-    object's :meth:`~basyx.aas.model.base.Referable.update` and :meth:`~basyx.aas.model.base.Referable.commit` methods
+    Each Backend class is typically capable of synchronizing (
+    updating/committing) objects with a type of external data source,
+    identified by one or more source URI schemas. Custom backends for
+    custom source URI schemas should inherit from this class and be
+    registered via :meth:`~basyx.aas.backend.backends
+    .register_backend`. to be used by DictObjectStore object's
+    :meth:`~basyx.aas.model.provider.DictObjectStore.update` and
+    :meth:`~basyx.aas.model.provider.DictObjectStore.commit` methods
     when required.
     """
 
@@ -45,34 +55,49 @@ class Backend(metaclass=abc.ABCMeta):
                       store_object: "Referable",
                       relative_path: List[str]) -> None:
         """
-        Function (class method) to be called when an object shall be committed (local changes pushed to the external
-        data source) via this backend implementation.
+        Function (class method) to be called when an object shall be
+        committed (local changes pushed to the external data source)
+        via this backend implementation.
 
-        It is automatically called by the :meth:`~basyx.aas.model.base.Referable.commit` implementation, when the source
-        URI of the object or the source URI one of its ancestors in the AAS object containment hierarchy include an
-        URI schema for which this
-        backend has been registered. Both of the objects are passed to this function: the one which shall be committed
-        (``committed_object``) and its ancestor with the relevant source URI (``store_object``). They may be the same,
-        the committed object has a source with the relevant schema itself. Additionally, the ``relative_path`` from the
+        It is automatically called by the
+        :meth:`~basyx.aas.model.provider.DictObjectStore.commit`
+        implementation, when the source URI of the object or the
+        source URI one of its ancestors in the AAS object containment
+        hierarchy include a URI schema for which this backend has
+        been registered. Both of the objects are passed to this
+        function: the one which shall be committed (
+        ``committed_object``) and its ancestor with the relevant
+        source URI (``store_object``). They may be the same,
+        the committed object has a source with the relevant schema
+        itself. Additionally, the ``relative_path`` from the
         ``store_object`` down to the ``committed_object`` is provided.
 
-        The backend MUST ensure to commit all local changes of at least the ``committed_object`` and all objects
-        contained within it (if any) to the data source. It MAY additionally commit changes to other objects (i.e. the
-        ``store_object`` and any additional contained object).
+        The backend MUST ensure to commit all local changes of at
+        least the ``committed_object`` and all objects contained
+        within it (if any) to the data source. It MAY additionally
+        commit changes to other objects (i.e. the ``store_object``
+        and any additional contained object).
 
-        For this purpose a concrete implementation of this method would typically use the ``source`` attribute of the
-        ``store_object`` to identify the data source. If the data source supports fine-grained access to contained
-        objects, the ``relative_path`` may become handy to compose the committed object's address within the data
-        source's interface.
+        For this purpose a concrete implementation of this method
+        would typically use the ``source`` attribute of the
+        ``store_object`` to identify the data source. If the data
+        source supports fine-grained access to contained objects,
+        the ``relative_path`` may become handy to compose the
+        committed object's address within the data source's interface.
 
-        :param committed_object: The object which shall be synced to the external data source
-        :param store_object: The object which originates from the relevant data source (i.e. has the relevant source
-            attribute). It may be the ``committed_object`` or one of its ancestors in the AAS object hierarchy.
-        :param relative_path: List of idShort strings to resolve the ``committed_object`` starting at the
-            ``store_object``, such that `obj = store_object; for i in relative_path: obj = obj.get_referable(i)`
-            resolves to the ``committed_object``. In case that ``store_object is committed_object``, it is an empty
-            list.
-        :raises BackendNotAvailableException: when the external data source cannot be reached
+        :param committed_object: The object which shall be synced to
+        the external data source :param store_object: The object
+        which originates from the relevant data source (i.e. has the
+        relevant source attribute). It may be the
+        ``committed_object`` or one of its ancestors in the AAS
+        object hierarchy. :param relative_path: List of idShort
+        strings to resolve the ``committed_object`` starting at the
+        ``store_object``, such that `obj = store_object; for i in
+        relative_path: obj = obj.get_referable(i)` resolves to the
+        ``committed_object``. In case that ``store_object is
+        committed_object``, it is an empty list. :raises
+        BackendNotAvailableException: when the external data source
+        cannot be reached
         """
         pass
 
@@ -83,33 +108,49 @@ class Backend(metaclass=abc.ABCMeta):
                       store_object: "Referable",
                       relative_path: List[str]) -> None:
         """
-        Function (class method) to be called when an object shall be updated (local object updated with changes from the
-        external data source) via this backend implementation.
+        Function (class method) to be called when an object shall be
+        updated (local object updated with changes from the external
+        data source) via this backend implementation.
 
-        It is automatically called by the :meth:`~basyx.aas.model.base.Referable.update` implementation,
-        when the source URI of the object or the source URI one of its ancestors in the AAS object containment hierarchy
-        include an URI schema for which this backend has been registered. Both of the objects are passed
-        to this function: the one which shall be update (``updated_object``) and its ancestor with
-        the relevant source URI (``store_object``). They may be the same, the updated object has a source with
-        the relevant schema itself. Additionally, the ``relative_path`` from the ``store_object`` down to
-        the ``updated_object`` is provided.
+        It is automatically called by the
+        :meth:`~basyx.aas.model.provider.DictObjectStore.update`
+        implementation, when the source URI of the object or the
+        source URI one of its ancestors in the AAS object containment
+        hierarchy include an URI schema for which this backend has
+        been registered. Both of the objects are passed to this
+        function: the one which shall be update (``updated_object``)
+        and its ancestor with the relevant source URI (
+        ``store_object``). They may be the same, the updated object
+        has a source with the relevant schema itself. Additionally,
+        the ``relative_path`` from the ``store_object`` down to the
+        ``updated_object`` is provided.
 
-        The backend MUST ensure to update at least the ``updated_object`` and all objects contained within it (if any)
-        with any changes from the data source. It MAY additionally update other objects (i.e. the ``store_object`` and
-        any additional contained object).
+        The backend MUST ensure to update at least the
+        ``updated_object`` and all objects contained within it (if
+        any) with any changes from the data source. It MAY
+        additionally update other objects (i.e. the ``store_object``
+        and any additional contained object).
 
-        For this purpose a concrete implementation of this method would typically use the ``source`` attribute of the
-        ``store_object`` to identify the data source. If the data source supports fine-grained access to contained
-        objects, the ``relative_path`` may become handy to compose the updated object's address within the data source's
-        interface.
+        For this purpose a concrete implementation of this method
+        would typically use the ``source`` attribute of the
+        ``store_object`` to identify the data source. If the data
+        source supports fine-grained access to contained objects,
+        the ``relative_path`` may become handy to compose the updated
+        object's address within the data source's interface.
 
-        :param updated_object: The object which shall be synced from the external data source
-        :param store_object: The object which originates from the relevant data source (i.e. has the relevant source
-            attribute). It may be the ``committed_object`` or one of its ancestors in the AAS object hierarchy.
-        :param relative_path: List of idShort strings to resolve the ``updated_object`` starting at the
-            ``store_object``, such that `obj = store_object; for i in relative_path: obj = obj.get_referable(i)`
-            resolves to the ``updated_object``. In case that ``store_object is updated_object``, it is an empty list.
-        :raises BackendNotAvailableException: when the external data source cannot be reached
+        :param updated_object: The object which shall be synced from
+        the external data source :param store_object: The object
+        which originates from the relevant data source (i.e. has the
+        relevant source attribute). It may be the
+        ``committed_object`` or one of its ancestors in the AAS
+        object hierarchy. :param relative_path: List of idShort
+        strings to resolve the ``updated_object`` starting at the
+        ``store_object``, such that `obj = store_object; for i in
+        relative_path: obj = obj.get_referable(i)` resolves to the
+        ``updated_object``. In case that ``store_object is
+        updated_object``, it is an empty list. :raises
+        BackendNotAvailableException: when the external data source
+        cannot be reached
         """
         pass
 
@@ -121,15 +162,19 @@ _backends_map: Dict[str, Type[Backend]] = {}
 
 def register_backend(scheme: str, backend_class: Type[Backend]) -> None:
     """
-    Register a Backend implementation to handle update/commit operations for a specific type of external data sources,
+    Register a Backend implementation to handle update/commit
+    operations for a specific type of external data sources,
     identified by a source URI schema.
 
-    This method may be called multiple times for a single Backend class, to register that class as a backend
-    implementation for different source URI schemas (e.g. use the same backend for 'http://' and 'https://' sources).
+    This method may be called multiple times for a single Backend
+    class, to register that class as a backend implementation for
+    different source URI schemas (e.g. use the same backend for
+    'http://' and 'https://' sources).
 
-    :param scheme: The URI schema of source URIs to be handled with Backend class, without trailing colon and slashes.
-        E.g. 'http', 'https', 'couchdb', etc.
-    :param backend_class: The Backend implementation class. Should inherit from :class:`Backend`.
+    :param scheme: The URI schema of source URIs to be handled with
+    Backend class, without trailing colon and slashes. E.g. 'http',
+    'https', 'couchdb', etc. :param backend_class: The Backend
+    implementation class. Should inherit from :class:`Backend`.
     """
     # TODO handle multiple backends per scheme
     _backends_map[scheme] = backend_class
@@ -140,12 +185,14 @@ RE_URI_SCHEME = re.compile(r"^([a-zA-Z][a-zA-Z+\-\.]*):")
 
 def get_backend(url: str) -> Type[Backend]:
     """
-    Internal function to retrieve the Backend implementation for the external data source identified by the given
-    ``url`` via the url's schema.
+    Internal function to retrieve the Backend implementation for the
+    external data source identified by the given ``url`` via the
+    url's schema.
 
-    :param url: External data source URI to find an appropriate Backend implementation for
-    :return: A Backend class, capable of updating/committing from/to the external data source
-    :raises UnknownBackendException: When no backend is available for that url
+    :param url: External data source URI to find an appropriate
+    Backend implementation for :return: A Backend class, capable of
+    updating/committing from/to the external data source :raises
+    UnknownBackendException: When no backend is available for that url
     """
     # TODO handle multiple backends per scheme
     scheme_match = RE_URI_SCHEME.match(url)
@@ -171,5 +218,6 @@ class UnknownBackendException(BackendError):
 
 
 class BackendNotAvailableException(BackendError):
-    """Raised, if the backend does exist in the registry, but is not available for some reason"""
+    """Raised, if the backend does exist in the registry, but is not
+    available for some reason"""
     pass

--- a/basyx/aas/backend/backends.py
+++ b/basyx/aas/backend/backends.py
@@ -41,8 +41,9 @@ class Backend(metaclass=abc.ABCMeta):
     updating/committing) objects with a type of external data source,
     identified by one or more source URI schemas. Custom backends for
     custom source URI schemas should inherit from this class and be
-    registered via :meth:`~basyx.aas.backend.backends
-    .register_backend`. to be used by DictObjectStore object's
+    registered via
+    :meth:`~basyx.aas.backend.backends.register_backend`. to be used by
+    DictObjectStore object's
     :meth:`~basyx.aas.model.provider.DictObjectStore.update` and
     :meth:`~basyx.aas.model.provider.DictObjectStore.commit` methods
     when required.

--- a/basyx/aas/backend/backends.py
+++ b/basyx/aas/backend/backends.py
@@ -4,7 +4,8 @@
 # the LICENSE file of this project.
 #
 # SPDX-License-Identifier: MIT
-"""This module provides a registry and abstract base class for
+"""
+This module provides a registry and abstract base class for
 Backends. A :class:`~.Backend` is a class that allows to synchronize
 Referable AAS objects or their included data with external data
 sources such as a remote API or a local source for real time data.
@@ -24,7 +25,8 @@ class methods. These are used internally by the objects'
 methods when the backend is applicable for the relevant source URI.
 Then, the Backend class needs to be registered to handle update/commit
 requests for a specific URI schema, using
-:meth:`~basyx.aas.backend.backends.register_backend`."""
+:meth:`~basyx.aas.backend.backends.register_backend`.
+"""
 import abc
 import re
 from typing import List, Dict, Type, TYPE_CHECKING
@@ -87,18 +89,19 @@ class Backend(metaclass=abc.ABCMeta):
         committed object's address within the data source's interface.
 
         :param committed_object: The object which shall be synced to
-        the external data source :param store_object: The object
-        which originates from the relevant data source (i.e. has the
-        relevant source attribute). It may be the
-        ``committed_object`` or one of its ancestors in the AAS
-        object hierarchy. :param relative_path: List of idShort
-        strings to resolve the ``committed_object`` starting at the
-        ``store_object``, such that `obj = store_object; for i in
-        relative_path: obj = obj.get_referable(i)` resolves to the
-        ``committed_object``. In case that ``store_object is
-        committed_object``, it is an empty list. :raises
-        BackendNotAvailableException: when the external data source
-        cannot be reached
+            the external data source
+        :param store_object: The object which originates from the
+            relevant data source (i.e. has the relevant source
+            attribute). It may be the ``committed_object`` or one of its
+            ancestors in the AAS object hierarchy.
+        :param relative_path: List of idShort strings to resolve the
+            ``committed_object`` starting at the ``store_object``,
+            such that `obj = store_object; for i in relative_path: obj =
+            obj.get_referable(i)` resolves to the ``committed_object``.
+            In case that ``store_object is committed_object``, it is an
+            empty list.
+        :raises BackendNotAvailableException: when the external data
+            source cannot be reached
         """
         pass
 
@@ -140,18 +143,19 @@ class Backend(metaclass=abc.ABCMeta):
         object's address within the data source's interface.
 
         :param updated_object: The object which shall be synced from
-        the external data source :param store_object: The object
-        which originates from the relevant data source (i.e. has the
-        relevant source attribute). It may be the
-        ``committed_object`` or one of its ancestors in the AAS
-        object hierarchy. :param relative_path: List of idShort
-        strings to resolve the ``updated_object`` starting at the
-        ``store_object``, such that `obj = store_object; for i in
-        relative_path: obj = obj.get_referable(i)` resolves to the
-        ``updated_object``. In case that ``store_object is
-        updated_object``, it is an empty list. :raises
-        BackendNotAvailableException: when the external data source
-        cannot be reached
+            the external data source
+        :param store_object: The object which originates from the
+            relevant data source (i.e. has the relevant source
+            attribute). It may be the ``committed_object`` or one of its
+            ancestors in the AAS object hierarchy.
+        :param relative_path: List of idShort strings to resolve the
+            ``updated_object`` starting at the ``store_object``,
+            such that `obj = store_object; for i in relative_path: obj =
+            obj.get_referable(i)` resolves to the ``updated_object``. In
+            case that ``store_object is updated_object``, it is an empty
+            list.
+        :raises BackendNotAvailableException: when the external data
+            source cannot be reached
         """
         pass
 
@@ -173,9 +177,10 @@ def register_backend(scheme: str, backend_class: Type[Backend]) -> None:
     'http://' and 'https://' sources).
 
     :param scheme: The URI schema of source URIs to be handled with
-    Backend class, without trailing colon and slashes. E.g. 'http',
-    'https', 'couchdb', etc. :param backend_class: The Backend
-    implementation class. Should inherit from :class:`Backend`.
+        Backend class, without trailing colon and slashes. E.g. 'http',
+        'https', 'couchdb', etc.
+    :param backend_class: The Backend implementation class. Should
+        inherit from :class:`Backend`.
     """
     # TODO handle multiple backends per scheme
     _backends_map[scheme] = backend_class
@@ -191,9 +196,10 @@ def get_backend(url: str) -> Type[Backend]:
     url's schema.
 
     :param url: External data source URI to find an appropriate
-    Backend implementation for :return: A Backend class, capable of
-    updating/committing from/to the external data source :raises
-    UnknownBackendException: When no backend is available for that url
+        Backend implementation for
+    :return: A Backend class, capable of updating/committing from/to
+        the external data source
+    :raises UnknownBackendException: When no backend is available for that url
     """
     # TODO handle multiple backends per scheme
     scheme_match = RE_URI_SCHEME.match(url)

--- a/basyx/aas/backend/backends.py
+++ b/basyx/aas/backend/backends.py
@@ -19,10 +19,10 @@ Custom backends for additional types of data sources can be
 implemented by subclassing :class:`Backend` and implementing the
 :meth:`~.Backend.commit_object` and :meth:`~.Backend.update_object`
 class methods. These are used internally by the objects'
-:meth:`~basyx.aas.model.provider.DictObjectStore.update` and
-:meth:`~basyx.aas.model.provider.DictObjectStore.commit` methods when
-the backend is applicable for the relevant source URI. Then,
-the Backend class needs to be registered to handle update/commit
+:meth:`~basyx.aas.model.provider.DictObjectStore.update_referable` and
+:meth:`~basyx.aas.model.provider.DictObjectStore.commit_referable`
+methods when the backend is applicable for the relevant source URI.
+Then, the Backend class needs to be registered to handle update/commit
 requests for a specific URI schema, using
 :meth:`~basyx.aas.backend.backends.register_backend`."""
 import abc
@@ -44,8 +44,8 @@ class Backend(metaclass=abc.ABCMeta):
     registered via
     :meth:`~basyx.aas.backend.backends.register_backend`. to be used by
     DictObjectStore object's
-    :meth:`~basyx.aas.model.provider.DictObjectStore.update` and
-    :meth:`~basyx.aas.model.provider.DictObjectStore.commit` methods
+    :meth:`~basyx.aas.model.provider.DictObjectStore.update_referable` and
+    :meth:`~basyx.aas.model.provider.DictObjectStore.commit_referable` methods
     when required.
     """
 
@@ -61,7 +61,7 @@ class Backend(metaclass=abc.ABCMeta):
         via this backend implementation.
 
         It is automatically called by the
-        :meth:`~basyx.aas.model.provider.DictObjectStore.commit`
+        :meth:`~basyx.aas.model.provider.DictObjectStore.commit_referable`
         implementation, when the source URI of the object or the
         source URI one of its ancestors in the AAS object containment
         hierarchy include a URI schema for which this backend has
@@ -114,7 +114,7 @@ class Backend(metaclass=abc.ABCMeta):
         data source) via this backend implementation.
 
         It is automatically called by the
-        :meth:`~basyx.aas.model.provider.DictObjectStore.update`
+        :meth:`~basyx.aas.model.provider.DictObjectStore.update_referable`
         implementation, when the source URI of the object or the
         source URI one of its ancestors in the AAS object containment
         hierarchy include an URI schema for which this backend has

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -57,7 +57,7 @@ class CouchDBBackend(backends.Backend):
 
         updated_store_object = data['data']
         set_couchdb_revision(url, data["_rev"])
-        obj_store: DictObjectStore = model.DictObjectStore()
+        obj_store: model.DictObjectStore = model.DictObjectStore()
         obj_store.update_from(store_object, updated_store_object)
 
     @classmethod

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -57,7 +57,8 @@ class CouchDBBackend(backends.Backend):
 
         updated_store_object = data['data']
         set_couchdb_revision(url, data["_rev"])
-        store_object.update_from(updated_store_object)
+        obj_store: DictObjectStore = model.DictObjectStore()
+        obj_store.update_from(store_object, updated_store_object)
 
     @classmethod
     def commit_object(cls,
@@ -317,7 +318,8 @@ class CouchDBObjectStore(model.AbstractObjectStore):
                 # If the source does not match the correct source for this CouchDB backend, the object seems to belong
                 # to another backend now, so we return a fresh copy
                 if old_obj.source == obj.source:
-                    old_obj.update_from(obj)
+                    obj_store: DictObjectStore = model.DictObjectStore()
+                    obj_store.update_from(old_obj, obj)
                     return old_obj
 
         self._object_cache[obj.id] = obj

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -318,7 +318,7 @@ class CouchDBObjectStore(model.AbstractObjectStore):
                 # If the source does not match the correct source for this CouchDB backend, the object seems to belong
                 # to another backend now, so we return a fresh copy
                 if old_obj.source == obj.source:
-                    obj_store: DictObjectStore = model.DictObjectStore()
+                    obj_store: model.DictObjectStore = model.DictObjectStore()
                     obj_store.update_from(old_obj, obj)
                     return old_obj
 

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -71,7 +71,7 @@ class CouchDBBackend(backends.Backend):
         url = CouchDBBackend._parse_source(store_object.source)
         # We need to get the revision of the object, if it already exists, otherwise we cannot write to the Couchdb
         if get_couchdb_revision(url) is None:
-            raise CouchDBConflictError("No revision found for the given object. Try calling `update` on it.")
+            raise CouchDBConflictError("No revision found for the given object. Try calling `update_referable` on it.")
 
         data = json.dumps({'data': store_object, "_rev": get_couchdb_revision(url)},
                           cls=json_serialization.AASToJsonEncoder)
@@ -183,7 +183,8 @@ def register_credentials(url: str, username: str, password: str):
     .. Warning::
 
         Do not use this function, while other threads may be accessing the credentials via the
-        :class:`~.CouchDBObjectStore` or update or commit functions of :class:`~.basyx.aas.model.provider.DictObjectStore`
+        :class:`~.CouchDBObjectStore` or update_referable or commit_referable functions
+        of :class:`~.basyx.aas.model.provider.DictObjectStore`
         objects!
 
     :param url: Toplevel URL

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -183,7 +183,7 @@ def register_credentials(url: str, username: str, password: str):
     .. Warning::
 
         Do not use this function, while other threads may be accessing the credentials via the
-        :class:`~.CouchDBObjectStore` or update or commit functions of :class:`~.basyx.aas.model.base.Referable`
+        :class:`~.CouchDBObjectStore` or update or commit functions of :class:`~.basyx.aas.model.provider.DictObjectStore`
         objects!
 
     :param url: Toplevel URL

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -48,7 +48,8 @@ class LocalFileBackend(backends.Backend):
         with open(file_name, "r") as file:
             data = json.load(file, cls=json_deserialization.AASFromJsonDecoder)
             updated_store_object = data["data"]
-            store_object.update_from(updated_store_object)
+            obj_store: model.DictObjectStore = model.DictObjectStore()
+            obj_store.update_from(store_object, updated_store_object)
 
     @classmethod
     def commit_object(cls,
@@ -123,7 +124,8 @@ class LocalFileObjectStore(model.AbstractObjectStore):
                 # If the source does not match the correct source for this CouchDB backend, the object seems to belong
                 # to another backend now, so we return a fresh copy
                 if old_obj.source == obj.source:
-                    old_obj.update_from(obj)
+                    obj_store: model.DictObjectStore = model.DictObjectStore()
+                    obj_store.update_from(old_obj, obj)
                     return old_obj
         self._object_cache[obj.id] = obj
         return obj

--- a/basyx/aas/examples/data/__init__.py
+++ b/basyx/aas/examples/data/__init__.py
@@ -34,9 +34,9 @@ def create_example() -> model.DictObjectStore:
     :return: object store
     """
     obj_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
-    obj_store.update(example_aas.create_full_example())
-    obj_store.update(example_aas_mandatory_attributes.create_full_example())
-    obj_store.update(example_aas_missing_attributes.create_full_example())
+    obj_store.add_from(example_aas.create_full_example())
+    obj_store.add_from(example_aas_mandatory_attributes.create_full_example())
+    obj_store.add_from(example_aas_missing_attributes.create_full_example())
     obj_store.add(example_submodel_template.create_example_submodel_template())
     return obj_store
 
@@ -50,9 +50,9 @@ def create_example_aas_binding() -> model.DictObjectStore:
     :return: object store
     """
     obj_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
-    obj_store.update(example_aas.create_full_example())
-    obj_store.update(example_aas_mandatory_attributes.create_full_example())
-    obj_store.update(example_aas_missing_attributes.create_full_example())
+    obj_store.add_from(example_aas.create_full_example())
+    obj_store.add_from(example_aas_mandatory_attributes.create_full_example())
+    obj_store.add_from(example_aas_missing_attributes.create_full_example())
     obj_store.add(example_submodel_template.create_example_submodel_template())
 
     aas = obj_store.get_identifiable('https://acplt.org/Test_AssetAdministrationShell')

--- a/basyx/aas/examples/tutorial_backend_couchdb.py
+++ b/basyx/aas/examples/tutorial_backend_couchdb.py
@@ -113,7 +113,7 @@ object_store.add(example_submodel2)
 
 # Fetch recent updates from the server
 obj_store: model.DictObjectStore = model.DictObjectStore()
-obj_store.update(example_submodel1)
+obj_store.update_referable(example_submodel1)
 
 # Make some changes to a Property within the submodel
 prop = example_submodel1.get_referable('ManufacturerName')
@@ -128,7 +128,7 @@ example_submodel1.id_short = 'NewIdShort'
 # source attribute of all ancestors in the object hierarchy (
 # including the Submodel) and commit the changes to all of these
 # external data sources.
-obj_store.commit(example_submodel1)
+obj_store.commit_referable(example_submodel1)
 
 
 ############

--- a/basyx/aas/examples/tutorial_backend_couchdb.py
+++ b/basyx/aas/examples/tutorial_backend_couchdb.py
@@ -112,7 +112,7 @@ object_store.add(example_submodel2)
 # application, so the CouchDB backend is loaded.
 
 # Fetch recent updates from the server
-obj_store: DictObjectStore = model.DictObjectStore()
+obj_store: model.DictObjectStore = model.DictObjectStore()
 obj_store.update(example_submodel1)
 
 # Make some changes to a Property within the submodel

--- a/basyx/aas/examples/tutorial_backend_couchdb.py
+++ b/basyx/aas/examples/tutorial_backend_couchdb.py
@@ -1,25 +1,29 @@
-#!/usr/bin/env python3
-# This work is licensed under a Creative Commons CCZero 1.0 Universal License.
-# See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
-"""
-Tutorial for storing Asset Administration Shells, Submodels and Assets in a CouchDB database server, using the
-CouchDBObjectStore and CouchDB Backend.
+# !/usr/bin/env python3 This work is licensed under a Creative
+# Commons CCZero 1.0 Universal License. See
+# http://creativecommons.org/publicdomain/zero/1.0/ for more
+# information.
+"""Tutorial for storing Asset Administration Shells, Submodels and
+Assets in a CouchDB database server, using the CouchDBObjectStore and
+CouchDB Backend.
 
-This tutorial also shows the usage of the commit()/update() mechanism for synchronizing objects with an external data
-source.
-"""
+This tutorial also shows the usage of the commit()/update() mechanism
+for synchronizing objects with an external data source."""
 
 from configparser import ConfigParser
 from pathlib import Path
 
 import basyx.aas.examples.data.example_aas
 import basyx.aas.backend.couchdb
+from basyx.aas import model
 
-# To execute this tutorial, you'll need a running CouchDB server, including an empty database and a user account with
-# access to that database.
-# After installing CouchDB, you can use the CouchDB web interface "Fauxton" (typically at
-# http://localhost:5984/_utils/) to create a new database. Optionally, you can create a new user by adding a document
-# to the `_users` database with the following contents (notice that the username is required in two positions):
+# To execute this tutorial, you'll need a running CouchDB server,
+# including an empty database and a user account with access to that
+# database.
+# After installing CouchDB, you can use the CouchDB web
+# interface "Fauxton" (typically at http://localhost:5984/_utils/) to
+# create a new database. Optionally, you can create a new user by
+# adding a document to the `_users` database with the following
+# contents (notice that the username is required in two positions):
 #
 #     {"_id": "org.couchdb.user:<your username>",
 #      "name": "<your username>",
@@ -27,8 +31,10 @@ import basyx.aas.backend.couchdb
 #      "roles": [],
 #      "type": "user"}
 #
-# Afterwards you can add the new user to the set of "Members" of your new database (via the "Permissions" section in the
-# user interface). Alternatively, you can use the admin credentials with the BaSyx Python SDK (see below).
+# Afterwards you can add the new user to the set of "Members" of your
+# new database (via the "Permissions" section in the user interface).
+# Alternatively, you can use the admin credentials with the BaSyx
+# Python SDK (see below).
 
 # Step-by-Step Guide:
 # step 1: connecting to a CouchDB server
@@ -40,13 +46,16 @@ import basyx.aas.backend.couchdb
 # Step 1: Connecting to a CouchDB Server #
 ##########################################
 
-# Well, actually, connections to the CouchDB server are created by the CouchDB backend, as required. However, we need
-# to provide the login credentials to the server for this to work.
+# Well, actually, connections to the CouchDB server are created by
+# the CouchDB backend, as required. However, we need to provide the
+# login credentials to the server for this to work.
 #
-# Here, we take the test configuration to work with BaSyx development environments. You should replace these with
-# the url of your CouchDB server (typically http://localhost:5984), the name of the empty database, and the name and
-# password of a CouchDB user account which is "member" of this database (see above). Alternatively, you can provide
-# your CouchDB server's admin credentials.
+# Here, we take the test configuration to work with BaSyx development
+# environments. You should replace these with the url of your CouchDB
+# server (typically http://localhost:5984), the name of the empty
+# database, and the name and password of a CouchDB user account which
+# is "member" of this database (see above). Alternatively, you can
+# provide your CouchDB server's admin credentials.
 config = ConfigParser()
 config.read([Path(__file__).parent.parent.parent.parent / 'test' / 'test_config.default.ini',
              Path(__file__).parent.parent.parent.parent / 'test' / 'test_config.ini'])
@@ -57,12 +66,14 @@ couchdb_user = config['couchdb']['user']
 couchdb_password = config['couchdb']['password']
 
 
-# Provide the login credentials to the CouchDB backend.
-# These credentials are used whenever communication with this CouchDB server is required either via the
-# CouchDBObjectStore or via the update()/commit() backend.
+# Provide the login credentials to the CouchDB backend. These
+# credentials are used whenever communication with this CouchDB
+# server is required either via the CouchDBObjectStore or via the
+# update()/commit() backend.
 basyx.aas.backend.couchdb.register_credentials(couchdb_url, couchdb_user, couchdb_password)
 
-# Now, we create a CouchDBObjectStore as an interface for managing the objects in the CouchDB server.
+# Now, we create a CouchDBObjectStore as an interface for managing
+# the objects in the CouchDB server.
 object_store = basyx.aas.backend.couchdb.CouchDBObjectStore(couchdb_url, couchdb_database)
 
 
@@ -74,9 +85,11 @@ object_store = basyx.aas.backend.couchdb.CouchDBObjectStore(couchdb_url, couchdb
 example_submodel1 = basyx.aas.examples.data.example_aas.create_example_asset_identification_submodel()
 example_submodel2 = basyx.aas.examples.data.example_aas.create_example_bill_of_material_submodel()
 
-# The CouchDBObjectStore behaves just like other ObjectStore implementations (see `tutorial_storage.py`). The objects
-# are transferred to the CouchDB immediately. Additionally, the `source` attribute is set automatically, so update() and
-# commit() will work automatically (see below).
+# The CouchDBObjectStore behaves just like other ObjectStore
+# implementations (see `tutorial_storage.py`). The objects are
+# transferred to the CouchDB immediately. Additionally, the `source`
+# attribute is set automatically, so update() and commit() will work
+# automatically (see below).
 object_store.add(example_submodel1)
 object_store.add(example_submodel2)
 
@@ -85,32 +98,44 @@ object_store.add(example_submodel2)
 # Step 3: Updating Objects from the CouchDB and Committing Changes #
 ####################################################################
 
-# Since the CouchDBObjectStore has set the `source` attribute of our Submodel objects, we can now use update() and
-# commit() to synchronize changes to these objects with the database. The `source` indicates (via its URI scheme) that
-# the CouchDB backend is used for the synchronization and references the correct CouchDB server url and database. For
-# this to work, we must make sure to `import aas.backend.couchdb` at least once in this Python application, so the
-# CouchDB backend is loaded.
+# The data integration mechanism of the BaSyx Python SDK allows to
+# synchronize objects with external data sources. This is done by the
+# update() and commit() methods of the `DictObjectStore`.
+#
+# Since the CouchDBObjectStore has set the `source` attribute of our
+# Submodel objects, we can now use update() and commit() to
+# synchronize changes to these objects with the database. The
+# `source` indicates (via its URI scheme) that the CouchDB backend is
+# used for the synchronization and references the correct CouchDB
+# server url and database. For this to work, we must make sure to
+# `import aas.backend.couchdb` at least once in this Python
+# application, so the CouchDB backend is loaded.
 
 # Fetch recent updates from the server
-example_submodel1.update()
+obj_store: DictObjectStore = model.DictObjectStore()
+obj_store.update(example_submodel1)
 
 # Make some changes to a Property within the submodel
 prop = example_submodel1.get_referable('ManufacturerName')
 assert isinstance(prop, basyx.aas.model.Property)
 
 prop.value = "RWTH Aachen"
+example_submodel1.id_short = 'NewIdShort'
 
 # Commit (upload) these changes to the CouchDB server
-# We can simply call commit() on the Property object. It will check the `source` attribute of the object itself as well
-# as the source attribute of all ancestors in the object hierarchy (including the Submodel) and commit the changes to
-# all of these external data sources.
-prop.commit()
+# We can simply call commit() with the `DictObjectStore`. It will
+# check the `source` attribute of the object itself as well as the
+# source attribute of all ancestors in the object hierarchy (
+# including the Submodel) and commit the changes to all of these
+# external data sources.
+obj_store.commit(example_submodel1)
 
 
 ############
 # Clean up #
 ############
 
-# Let's delete the Submodels from the CouchDB to leave it in a clean state
+# Let's delete the Submodels from the CouchDB to leave it in a clean
+# state
 object_store.discard(example_submodel1)
 object_store.discard(example_submodel2)

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -98,9 +98,8 @@ submodel_and_aas = json.loads(json_string, cls=basyx.aas.adapter.json.AASFromJso
 # Step 4: Writing Multiple Identifiable Objects to a (Standard-compliant) JSON/XML File #
 #########################################################################################
 
-# step 4.1: creating an ObjectStore containing the objects to be serialized
+# step 4.1: add the objects to be serialized using the ObjectStore
 # For more information, take a look into `tutorial_storage.py`
-obj_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
 obj_store.add(submodel)
 obj_store.add(aashell)
 

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -59,7 +59,8 @@ aashell = model.AssetAdministrationShell(
 # Before serializing the data, we should make sure, it's up-to-date. This is irrelevant for the static AAS objects in
 # this tutorial, but may be important when dealing with dynamic data.
 # See `tutorial_dynamic_model.py` for more information on that topic.
-aashell.update()
+obj_store: model.DictObjectStore = model.DictObjectStore()
+obj_store.update_referable(aashell)
 
 # `AASToJsonEncoder` from the `aas.adapter.json` module is a custom JSONEncoder class for serializing
 # Asset Administration Shell data into the official JSON format according to
@@ -104,8 +105,8 @@ obj_store.add(submodel)
 obj_store.add(aashell)
 
 # step 4.2: Again, make sure that the data is up-to-date
-submodel.update()
-aashell.update()
+obj_store.update_referable(submodel)
+obj_store.update_referable(aashell)
 
 # step 4.3: writing the contents of the ObjectStore to a JSON file
 basyx.aas.adapter.json.write_aas_json_file('data.json', obj_store)

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1919,6 +1919,50 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
         backend, case_sensitive = self._backend[attribute_name]
         return backend.get(attribute_value if case_sensitive else attribute_value.upper(), default)
 
+    # Todo: Implement function including tests
+    def update_nss_from(self, other: "NamespaceSet"):
+        """
+        Update a NamespaceSet from a given NamespaceSet.
+
+        WARNING: By updating, the "other" NamespaceSet gets destroyed.
+
+        :param other: The NamespaceSet to update from
+        """
+        objects_to_add: List[_NSO] = []  # objects from the other nss to add to self
+        objects_to_remove: List[_NSO] = []  # objects to remove from self
+        for other_object in other:
+            try:
+                if isinstance(other_object, Referable):
+                    backend, case_sensitive = self._backend["id_short"]
+                    referable = backend[other_object.id_short if case_sensitive else other_object.id_short.upper()]
+                    obj_store: model.DictObjectStore = model.DictObjectStore()
+                    obj_store.update_from(referable, other_object,
+                                          update_source=True)  # type: ignore
+                elif isinstance(other_object, Qualifier):
+                    backend, case_sensitive = self._backend["type"]
+                    qualifier = backend[other_object.type if case_sensitive else other_object.type.upper()]
+                    # qualifier.update_from(other_object, update_source=True) # TODO: What should happend here?
+                elif isinstance(other_object, Extension):
+                    backend, case_sensitive = self._backend["name"]
+                    extension = backend[other_object.name if case_sensitive else other_object.name.upper()]
+                    # extension.update_from(other_object, update_source=True) # TODO: What should happend here?
+                else:
+                    raise TypeError("Type not implemented")
+            except KeyError:
+                # other object is not in NamespaceSet
+                objects_to_add.append(other_object)
+        for attr_name, (backend, case_sensitive) in self._backend.items():
+            for attr_name_other, (backend_other, case_sensitive_other) in other._backend.items():
+                if attr_name is attr_name_other:
+                    for item in backend.values():
+                        if not backend_other.get(self._get_attribute(item, attr_name, case_sensitive)):
+                            # referable does not exist in the other NamespaceSet
+                            objects_to_remove.append(item)
+        for object_to_add in objects_to_add:
+            other.remove(object_to_add)
+            self.add(object_to_add)  # type: ignore
+        for object_to_remove in objects_to_remove:
+            self.remove(object_to_remove)  # type: ignore
 
 class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NSO]):
     """

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -18,7 +18,6 @@ from typing import List, Optional, Set, TypeVar, MutableSet, Generic, Iterable, 
 import re
 
 from . import datatypes, _string_constraints
-from ..backend import backends
 
 if TYPE_CHECKING:
     from . import provider
@@ -732,131 +731,6 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
                 set_.add(self)
         # Redundant to the line above. However this way, we make sure that we really update the _id_short
         self._id_short = id_short
-
-    def update(self,
-               max_age: float = 0,
-               recursive: bool = True,
-               _indirect_source: bool = True) -> None:
-        """
-        Update the local Referable object from any underlying external data source, using an appropriate backend
-
-        If there is no source given, it will find its next ancestor with a source and update from this source.
-        If there is no source in any ancestor, this function will do nothing
-
-        :param max_age: Maximum age of the local data in seconds. This method may return early, if the previous update
-                        of the object has been performed less than ``max_age`` seconds ago.
-        :param recursive: Also call update on all children of this object. Default is True
-        :param _indirect_source: Internal parameter to avoid duplicate updating.
-        :raises backends.BackendError: If no appropriate backend or the data source is not available
-        """
-        # TODO consider max_age
-        if not _indirect_source:
-            # Update was already called on an ancestor of this Referable. Only update it, if it has its own source
-            if self.source != "":
-                backends.get_backend(self.source).update_object(updated_object=self,
-                                                                store_object=self,
-                                                                relative_path=[])
-
-        else:
-            # Try to find a valid source for this Referable
-            if self.source != "":
-                backends.get_backend(self.source).update_object(updated_object=self,
-                                                                store_object=self,
-                                                                relative_path=[])
-            else:
-                store_object, relative_path = self.find_source()
-                if store_object and relative_path is not None:
-                    backends.get_backend(store_object.source).update_object(updated_object=self,
-                                                                            store_object=store_object,
-                                                                            relative_path=list(relative_path))
-
-        if recursive:
-            # update all the children who have their own source
-            if isinstance(self, UniqueIdShortNamespace):
-                for namespace_set in self.namespace_element_sets:
-                    if "id_short" not in namespace_set.get_attribute_name_list():
-                        continue
-                    for referable in namespace_set:
-                        referable.update(max_age, recursive=True, _indirect_source=False)
-
-    def find_source(self) -> Tuple[Optional["Referable"], Optional[List[str]]]:  # type: ignore
-        """
-        Finds the closest source in this objects ancestors. If there is no source, returns None
-
-        :return: Tuple with the closest ancestor with a defined source and the relative path of id_shorts to that
-                 ancestor
-        """
-        referable: Referable = self
-        relative_path: List[NameType] = [self.id_short]
-        while referable is not None:
-            if referable.source != "":
-                relative_path.reverse()
-                return referable, relative_path
-            if referable.parent:
-                assert isinstance(referable.parent, Referable)
-                referable = referable.parent
-                relative_path.append(referable.id_short)
-                continue
-            break
-        return None, None
-
-    def update_from(self, other: "Referable", update_source: bool = False):
-        """
-        Internal function to updates the object's attributes from another object of a similar type.
-
-        This function should not be used directly. It is typically used by backend implementations (database adapters,
-        protocol clients, etc.) to update the object's data, after ``update()`` has been called.
-
-        :param other: The object to update from
-        :param update_source: Update the source attribute with the other's source attribute. This is not propagated
-                              recursively
-        """
-        for name, var in vars(other).items():
-            # do not update the parent, namespace_element_sets or source (depending on update_source parameter)
-            if name in ("parent", "namespace_element_sets") or name == "source" and not update_source:
-                continue
-            if isinstance(var, NamespaceSet):
-                # update the elements of the NameSpaceSet
-                vars(self)[name].update_nss_from(var)
-            else:
-                vars(self)[name] = var  # that variable is not a NameSpaceSet, so it isn't Referable
-
-    def commit(self) -> None:
-        """
-        Transfer local changes on this object to all underlying external data sources.
-
-        This function commits the current state of this object to its own and each external data source of its
-        ancestors. If there is no source, this function will do nothing.
-        """
-        current_ancestor = self.parent
-        relative_path: List[NameType] = [self.id_short]
-        # Commit to all ancestors with sources
-        while current_ancestor:
-            assert isinstance(current_ancestor, Referable)
-            if current_ancestor.source != "":
-                backends.get_backend(current_ancestor.source).commit_object(committed_object=self,
-                                                                            store_object=current_ancestor,
-                                                                            relative_path=list(relative_path))
-            relative_path.insert(0, current_ancestor.id_short)
-            current_ancestor = current_ancestor.parent
-        # Commit to own source and check if there are children with sources to commit to
-        self._direct_source_commit()
-
-    def _direct_source_commit(self):
-        """
-        Commits children of an ancestor recursively, if they have a specific source given
-        """
-        if self.source != "":
-            backends.get_backend(self.source).commit_object(committed_object=self,
-                                                            store_object=self,
-                                                            relative_path=[])
-
-        if isinstance(self, UniqueIdShortNamespace):
-            for namespace_set in self.namespace_element_sets:
-                if "id_short" not in namespace_set.get_attribute_name_list():
-                    continue
-                for referable in namespace_set:
-                    referable._direct_source_commit()
 
     id_short = property(_get_id_short, _set_id_short)
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1964,6 +1964,7 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
         for object_to_remove in objects_to_remove:
             self.remove(object_to_remove)  # type: ignore
 
+
 class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NSO]):
     """
     A specialized version of :class:`~.NamespaceSet`, that keeps track of the order of the stored

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -121,7 +121,7 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
         :param identifier: :class:`~basyx.aas.model.base.Identifier`
         of the object to update
         :param max_age: Maximum age of the local data in seconds. This method may return early, if the previous update
-                        of the object has been performed less than ``max_age`` seconds ago.
+        of the object has been performed less than ``max_age`` seconds ago.
         :param recursive: Also call update on all children of this object. Default is True
         :param _indirect_source: Internal parameter to avoid duplicate updating.
         :raises backends.BackendError: If no appropriate backend or the data source is not available

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -126,7 +126,7 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
 
         :param referable: The object to update
         :param max_age: Maximum age of the local data in seconds. This method may return early, if the previous update
-        of the object has been performed less than ``max_age`` seconds ago.
+            of the object has been performed less than ``max_age`` seconds ago.
         :param recursive: Also call update on all children of this object. Default is True
         :param _indirect_source: Internal parameter to avoid duplicate updating.
         :raises backends.BackendError: If no appropriate backend or the data source is not available

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -119,7 +119,6 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
                          max_age: float = 0,
                          recursive: bool = True,
                          _indirect_source: bool = True) -> None:
-        # TODO: discuss the method name and signature used here
         """
         Update the local Referable object from any underlying external data source, using an appropriate backend
 
@@ -149,7 +148,8 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
                     store_object=referable,
                     relative_path=[])
             else:
-                store_object, relative_path = self.find_source(referable)
+                store_object, relative_path = self.find_source(
+                    referable)
                 if store_object and relative_path is not None:
                     backends.get_backend(
                         store_object.source).update_object(
@@ -165,7 +165,8 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
                         continue
                     for referable in namespace_set:
                         obj_store: model.DictObjectStore = model.DictObjectStore()
-                        obj_store.update_referable(referable, max_age, recursive=True,
+                        obj_store.update_referable(referable, max_age,
+                                                   recursive=True,
                                                    _indirect_source=False)
 
     def find_source(self, obj) -> Tuple[
@@ -190,14 +191,16 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
             break
         return None, None
 
-    def update_from(self, referable: "Referable", other: "Referable",
-                    update_source: bool = False):
+    def update_from(self, obj, other: "Referable",
+                    update_source: bool = False):  # type: ignore
         """
         Internal function to updates the object's attributes from another object of a similar type.
 
         This function should not be used directly. It is typically used by backend implementations (database adapters,
-        protocol clients, etc.) to update the object's data, after ``update()`` has been called.
+        protocol clients, etc.) to update the object's data,
+        after ``update()_referable`` has been called.
 
+        :param obj: The object to update
         :param other: The object to update from
         :param update_source: Update the source attribute with the other's source attribute. This is not propagated
                               recursively
@@ -209,9 +212,9 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
                 continue
             if isinstance(var, NamespaceSet):
                 # update the elements of the NameSpaceSet
-                vars(referable)[name].update_nss_from(var)
+                vars(obj)[name].update_nss_from(var)
             else:
-                vars(referable)[
+                vars(obj)[
                     name] = var  # that variable is not a NameSpaceSet, so it isn't Referable
 
     def commit_referable(self, referable: "Referable") -> None:

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -45,8 +45,7 @@ class AbstractObjectProvider(metaclass=abc.ABCMeta):
         pass
 
     def get(self, identifier: Identifier,
-            default: Optional[Identifiable] = None) -> Optional[
-        Identifiable]:
+            default: Optional[Identifiable] = None) -> Optional[Identifiable]:
         """
         Find an object in this set by its :class:`id <basyx.aas.model.base.Identifier>`, with fallback parameter
 
@@ -169,8 +168,7 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
                                                    recursive=True,
                                                    _indirect_source=False)
 
-    def find_source(self, obj) -> Tuple[
-        Optional["Referable"], Optional[List[str]]]:  # type: ignore
+    def find_source(self, obj) -> Tuple[Optional["Referable"], Optional[List[str]]]:  # type: ignore
         """
         Finds the closest source in this objects ancestors. If there is no source, returns None
 
@@ -283,8 +281,7 @@ class ObjectProviderMultiplexer(AbstractObjectProvider):
                       object
     """
 
-    def __init__(self, registries: Optional[
-        List[AbstractObjectProvider]] = None):
+    def __init__(self, registries: Optional[List[AbstractObjectProvider]] = None):
         self.providers: List[
             AbstractObjectProvider] = registries if registries is not None else []
 

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -118,9 +118,10 @@ class LocalFileBackendTest(unittest.TestCase):
 
         # Test if commit uploads changes
         test_object.id_short = "SomeNewIdShort"
-        test_object.commit()
+        obj_store: model.DictObjectStore = model.DictObjectStore()
+        obj_store.commit_referable(test_object)
 
         # Test if update restores changes
         test_object.id_short = "AnotherIdShort"
-        test_object.update()
+        obj_store.update_referable(test_object)
         self.assertEqual("SomeNewIdShort", test_object.id_short)

--- a/test/examples/test_tutorials.py
+++ b/test/examples/test_tutorials.py
@@ -15,8 +15,7 @@ import unittest
 from contextlib import contextmanager
 
 from basyx.aas import model
-from test._helper.test_helpers import (COUCHDB_OKAY, TEST_CONFIG,
-                                    COUCHDB_ERROR)
+from test._helper.test_helpers import (COUCHDB_OKAY, TEST_CONFIG, COUCHDB_ERROR)
 
 
 class TutorialTest(unittest.TestCase):

--- a/test/examples/test_tutorials.py
+++ b/test/examples/test_tutorials.py
@@ -15,7 +15,8 @@ import unittest
 from contextlib import contextmanager
 
 from basyx.aas import model
-from .._helper.test_helpers import COUCHDB_OKAY, TEST_CONFIG, COUCHDB_ERROR
+from test._helper.test_helpers import (COUCHDB_OKAY, TEST_CONFIG,
+                                    COUCHDB_ERROR)
 
 
 class TutorialTest(unittest.TestCase):

--- a/test/model/test_provider.py
+++ b/test/model/test_provider.py
@@ -51,7 +51,7 @@ class ProvidersTest(unittest.TestCase):
         object_store1.add(self.aas1)
         object_store2: model.DictObjectStore[model.AssetAdministrationShell] = model.DictObjectStore()
         object_store2.add(self.aas2)
-        object_store1.update(object_store2)
+        object_store1.add_from(object_store2)
         self.assertIsInstance(object_store1, model.DictObjectStore)
         self.assertIn(self.aas2, object_store1)
 


### PR DESCRIPTION
Previously, the `update()` and `commit()` functions were part of the `model.base.Referable` class. 
While this made them easy to use, we had lots of cross-dependencies and it made these two functions hard to maintain. 

Therefore, we decided to refactor both functions to be part of the `model.provider.AbstractObjectStore`. 
This PR moves the two functions and adapts the necessary tests and tutorials. 