### PR TITLE
update constraint AASd-002

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -770,7 +770,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         _string_constraints.check_name_type(id_short)
         test_id_short: NameType = str(id_short)
-        if not re.fullmatch("[A-Za-z]|[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9_]", test_id_short):
+        if not re.fullmatch("[A-Za-z0-9_-]*", test_id_short):
             raise AASConstraintViolation(
                 2,
                 "The id_short must contain only letters, digits underscore and hyphen"

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -596,8 +596,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     **Constraint AASd-001:** In case of a referable element not being an identifiable element the
     idShort is mandatory and used for referring to the element in its name space.
 
-    **Constraint AASd-002:** idShort shall only feature letters, digits, underscore (``_``); starting
-    mandatory with a letter.
+    **Constraint AASd-002:** idShort shall only feature letters, digits, underscore (``_``), hyphen (``-``);
+    starting mandatory with a letter and not ending with a hyphen.
+    I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``
 
     **Constraint AASd-004:** Add parent in case of non-identifiable elements.
 
@@ -758,8 +759,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         Validates an id_short against Constraint AASd-002 and :class:`NameType` restrictions.
 
-        **Constraint AASd-002:** idShort of Referables shall only feature letters, digits, underscore (``_``); starting
-        mandatory with a letter. I.e. ``[a-zA-Z][a-zA-Z0-9_]+``
+        **Constraint AASd-002:** idShort shall only feature letters, digits, underscore (``_``), hyphen (``-``);
+        starting mandatory with a letter and not ending with a hyphen.
+        I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``
 
         :param id_short: The id_short to validate
         :raises ValueError: If the id_short doesn't comply to the constraints imposed by :class:`NameType`
@@ -768,15 +770,20 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         _string_constraints.check_name_type(id_short)
         test_id_short: NameType = str(id_short)
-        if not re.fullmatch("[a-zA-Z0-9_]*", test_id_short):
+        if not re.fullmatch("[A-Za-z]|[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9_]", test_id_short):
             raise AASConstraintViolation(
                 2,
-                "The id_short must contain only letters, digits and underscore"
+                "The id_short must contain only letters, digits underscore and hyphen"
             )
         if not test_id_short[0].isalpha():
             raise AASConstraintViolation(
                 2,
                 "The id_short must start with a letter"
+            )
+        if test_id_short.endswith("-"):
+            raise AASConstraintViolation(
+                2,
+                "The id_short must not end with a hyphen"
             )
 
     category = property(_get_category, _set_category)
@@ -785,8 +792,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         Check the input string
 
-        **Constraint AASd-002:** idShort of Referables shall only feature letters, digits, underscore (``_``); starting
-        mandatory with a letter. I.e. ``[a-zA-Z][a-zA-Z0-9_]+``
+        **Constraint AASd-002:** idShort shall only feature letters, digits, underscore (``_``), hyphen (``-``);
+        starting mandatory with a letter and not ending with a hyphen.
+        I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``
 
         **Constraint AASd-022:** idShort of non-identifiable referables shall be unique in its namespace
         (case-sensitive)

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -14,7 +14,7 @@ The status information means the following:
 In most cases, if a constraint violation is detected,
 an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 
-.. |aasd002| replace:: ``idShort`` of ``Referable`` s shall only feature letters, digits, underscore (``_``), hyphen (``-``); starting mandatory with a letter and not ending with a hyphen. I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``
+.. |aasd002| replace:: ``idShort`` of ``Referable`` s shall only feature letters, digits, underscore (``_``), hyphen (``-``); starting mandatory with a letter and not ending with a hyphen. I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``.
 .. |aasd005| replace:: If ``AdministrativeInformation/version`` is not specified, ``AdministrativeInformation/revision`` shall also be unspecified. This means that a revision requires a version. If there is no version, there is no revision. Revision is optional.
 .. |aasd006| replace:: If both, the ``value`` and the ``valueId`` of a ``Qualifier`` are present, the value needs to be identical to the value of the referenced coded value in ``Qualifier/valueId``.
 .. |aasd007| replace:: If both the ``Property/value`` and the ``Property/valueId`` are present, the value of ``Property/value`` needs to be identical to the value of the referenced coded value in ``Property/valueId``.

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -14,7 +14,7 @@ The status information means the following:
 In most cases, if a constraint violation is detected,
 an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 
-.. |aasd002| replace:: ``idShort`` of ``Referable`` s shall only feature letters, digits, underscore (``_``); starting mandatory with a letter, i.e. ``[a-zA-Z][a-zA-Z0-9_]*``.
+.. |aasd002| replace:: ``idShort`` of ``Referable`` s shall only feature letters, digits, underscore (``_``), hyphen (``-``); starting mandatory with a letter and not ending with a hyphen. I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``
 .. |aasd005| replace:: If ``AdministrativeInformation/version`` is not specified, ``AdministrativeInformation/revision`` shall also be unspecified. This means that a revision requires a version. If there is no version, there is no revision. Revision is optional.
 .. |aasd006| replace:: If both, the ``value`` and the ``valueId`` of a ``Qualifier`` are present, the value needs to be identical to the value of the referenced coded value in ``Qualifier/valueId``.
 .. |aasd007| replace:: If both the ``Property/value`` and the ``Property/valueId`` are present, the value of ``Property/value`` needs to be identical to the value of the referenced coded value in ``Property/valueId``.

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -100,10 +100,15 @@ class ReferableTest(unittest.TestCase):
         test_object = ExampleReferable()
         test_object.id_short = "Test"
         self.assertEqual("Test", test_object.id_short)
-        test_object.id_short = "asdASd123_"
-        self.assertEqual("asdASd123_", test_object.id_short)
+        test_object.id_short = "asdASd-123_"
+        self.assertEqual("asdASd-123_", test_object.id_short)
         test_object.id_short = "AAs12_"
         self.assertEqual("AAs12_", test_object.id_short)
+        test_object.id_short = "A"
+        self.assertEqual("A", test_object.id_short)
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            test_object.id_short = "Test-"
+        self.assertEqual("The id_short must not end with a hyphen (Constraint AASd-002)", str(cm.exception))
         with self.assertRaises(model.AASConstraintViolation) as cm:
             test_object.id_short = "98sdsfdAS"
         self.assertEqual("The id_short must start with a letter (Constraint AASd-002)", str(cm.exception))
@@ -113,12 +118,12 @@ class ReferableTest(unittest.TestCase):
         with self.assertRaises(model.AASConstraintViolation) as cm:
             test_object.id_short = "asdlujSAD8348@S"
         self.assertEqual(
-            "The id_short must contain only letters, digits and underscore (Constraint AASd-002)",
+            "The id_short must contain only letters, digits underscore and hyphen (Constraint AASd-002)",
             str(cm.exception))
         with self.assertRaises(model.AASConstraintViolation) as cm:
             test_object.id_short = "abc\n"
         self.assertEqual(
-            "The id_short must contain only letters, digits and underscore (Constraint AASd-002)",
+            "The id_short must contain only letters, digits underscore and hyphen (Constraint AASd-002)",
             str(cm.exception))
 
     def test_representation(self):


### PR DESCRIPTION
See [here](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#_metamodel_changes_v3_1_vs_v3_0_2) for the changes.