### PR TITLE
update metamodel element IDs and links to V3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are the implemented AAS specifications of the [current SDK release](https:
 
 | Specification                         | Version                                                                                                                                                                         |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Part 1: Metamodel                     | [v3.1.2 (01001-3-0-1)](https://industrialdigitaltwin.org/wp-content/uploads/2025/11/IDTA-01001-3-1-2_AAS-Specification_Part1_Metamodel.pdf)                 |
+| Part 1: Metamodel                     | [v3.1.2 (01001-3-0-1)](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/index.html)                 |
 | Schemata (JSONSchema, XSD)            | [v3.0.8 (IDTA-01001-3-0-1_schemasV3.0.8)](https://github.com/admin-shell-io/aas-specs/releases/tag/IDTA-01001-3-0-1_schemasV3.0.8)                                              |
 | Part 2: API                           | [v3.0 (01002-3-0)](https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2023/06/IDTA-01002-3-0_SpecificationAssetAdministrationShell_Part2_API_.pdf)                 |
 | Part 3a: Data Specification IEC 61360 | [v3.0 (01003-a-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01003-a-3-0_SpecificationAssetAdministrationShell_Part3a_DataSpecification_IEC61360.pdf) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are the implemented AAS specifications of the [current SDK release](https:
 
 | Specification                         | Version                                                                                                                                                                         |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Part 1: Metamodel                     | [v3.0.1 (01001-3-0-1)](https://industrialdigitaltwin.org/wp-content/uploads/2024/06/IDTA-01001-3-0-1_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf)                   |
+| Part 1: Metamodel                     | [v3.1.2 (01001-3-0-1)](https://industrialdigitaltwin.org/wp-content/uploads/2025/11/IDTA-01001-3-1-2_AAS-Specification_Part1_Metamodel.pdf)                 |
 | Schemata (JSONSchema, XSD)            | [v3.0.8 (IDTA-01001-3-0-1_schemasV3.0.8)](https://github.com/admin-shell-io/aas-specs/releases/tag/IDTA-01001-3-0-1_schemasV3.0.8)                                              |
 | Part 2: API                           | [v3.0 (01002-3-0)](https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2023/06/IDTA-01002-3-0_SpecificationAssetAdministrationShell_Part2_API_.pdf)                 |
 | Part 3a: Data Specification IEC 61360 | [v3.0 (01003-a-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01003-a-3-0_SpecificationAssetAdministrationShell_Part3a_DataSpecification_IEC61360.pdf) |

--- a/sdk/basyx/aas/adapter/_generic.py
+++ b/sdk/basyx/aas/adapter/_generic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/adapter/_generic.py
+++ b/sdk/basyx/aas/adapter/_generic.py
@@ -27,7 +27,7 @@ JSON_AAS_TOP_LEVEL_KEYS_TO_TYPES = (
 )
 
 # XML Namespace definition
-XML_NS_MAP = {"aas": "https://admin-shell.io/aas/3/0"}
+XML_NS_MAP = {"aas": "https://admin-shell.io/aas/3/1"}
 XML_NS_AAS = "{" + XML_NS_MAP["aas"] + "}"
 
 MODELLING_KIND: Dict[model.ModellingKind, str] = {

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -98,7 +98,7 @@ def _element_pretty_identifier(element: etree._Element) -> str:
 
     If the prefix is known, the namespace in the element tag is replaced by the prefix.
     If additionally also the sourceline is known, it is added as a suffix to name.
-    For example, instead of "{https://admin-shell.io/aas/3/0}assetAdministrationShell" this function would return
+    For example, instead of "{https://admin-shell.io/aas/3/1}assetAdministrationShell" this function would return
     "aas:assetAdministrationShell on line $line", if both, prefix and sourceline, are known.
 
     :param element: The xml element.

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 _embedded_data_specification_iec61360 = model.EmbeddedDataSpecification(
     data_specification=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                           value='https://admin-shell.io/DataSpecificationTemplates/'
-                                                                'DataSpecificationIEC61360/3/0'),)),
+                                                                'DataSpecificationIEC61360/3/1'),)),
     data_specification_content=model.DataSpecificationIEC61360(preferred_name=model.PreferredNameTypeIEC61360({
         'de': 'Test Specification',
         'en-US': 'TestSpecification'

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1182,7 +1182,7 @@ class DataSpecificationContent:
     **Constraint AASc-3a-050:** If the ``Data_specification_IEC_61360`` is used
     for an element, the value of ``HasDataSpecification.embedded_data_specifications``
     shall contain the external reference to the IRI of the corresponding data specification
-    template ``https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0``
+    template ``https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/1``
     """
     @abc.abstractmethod
     def __init__(self):

--- a/sdk/test/adapter/xml/test_xml_deserialization.py
+++ b/sdk/test/adapter/xml/test_xml_deserialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/adapter/xml/test_xml_deserialization.py
+++ b/sdk/test/adapter/xml/test_xml_deserialization.py
@@ -450,22 +450,22 @@ class XmlDeserializationDerivingTest(unittest.TestCase):
 
 class TestTagReplaceNamespace(unittest.TestCase):
     def test_known_namespace(self):
-        tag = '{https://admin-shell.io/aas/3/0}tag'
+        tag = '{https://admin-shell.io/aas/3/1}tag'
         expected = 'aas:tag'
         self.assertEqual(_tag_replace_namespace(tag, XML_NS_MAP), expected)
 
     def test_empty_prefix(self):
         # Empty prefix should not be replaced as otherwise it would apply everywhere
-        tag = '{https://admin-shell.io/aas/3/0}tag'
-        nsmap = {"": "https://admin-shell.io/aas/3/0"}
-        expected = '{https://admin-shell.io/aas/3/0}tag'
+        tag = '{https://admin-shell.io/aas/3/1}tag'
+        nsmap = {"": "https://admin-shell.io/aas/3/1"}
+        expected = '{https://admin-shell.io/aas/3/1}tag'
         self.assertEqual(_tag_replace_namespace(tag, nsmap), expected)
 
     def test_empty_namespace(self):
         # Empty namespaces should also have no effect
-        tag = '{https://admin-shell.io/aas/3/0}tag'
+        tag = '{https://admin-shell.io/aas/3/1}tag'
         nsmap = {"aas": ""}
-        expected = '{https://admin-shell.io/aas/3/0}tag'
+        expected = '{https://admin-shell.io/aas/3/1}tag'
         self.assertEqual(_tag_replace_namespace(tag, nsmap), expected)
 
     def test_unknown_namespace(self):


### PR DESCRIPTION
See [here](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#_metamodel_changes_v3_1_vs_v3_0_2) for the changes.