### PR TITLE
update RelationshipElemet first and second to be optional

### DIFF
--- a/sdk/basyx/aas/adapter/xml/xml_serialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_serialization.py
@@ -733,8 +733,10 @@ def relationship_element_to_xml(obj: model.RelationshipElement,
     :return: Serialized :class:`~lxml.etree._Element` object
     """
     et_relationship_element = abstract_classes_to_xml(tag, obj)
-    et_relationship_element.append(reference_to_xml(obj.first, NS_AAS+"first"))
-    et_relationship_element.append(reference_to_xml(obj.second, NS_AAS+"second"))
+    if obj.first is not None:
+        et_relationship_element.append(reference_to_xml(obj.first, NS_AAS+"first"))
+    if obj.second is not None:
+        et_relationship_element.append(reference_to_xml(obj.second, NS_AAS+"second"))
     return et_relationship_element
 
 

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -860,8 +860,8 @@ class RelationshipElement(SubmodelElement):
 
     def __init__(self,
                  id_short: Optional[base.NameType],
-                 first: base.Reference,
-                 second: base.Reference,
+                 first: Optional[base.Reference] = None,
+                 second: Optional[base.Reference] = None,
                  display_name: Optional[base.MultiLanguageNameType] = None,
                  category: Optional[base.NameType] = None,
                  description: Optional[base.MultiLanguageTextType] = None,
@@ -877,8 +877,8 @@ class RelationshipElement(SubmodelElement):
 
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
-        self.first: base.Reference = first
-        self.second: base.Reference = second
+        self.first: Optional[base.Reference] = first
+        self.second: Optional[base.Reference] = second
 
 
 class AnnotatedRelationshipElement(RelationshipElement, base.UniqueIdShortNamespace):


### PR DESCRIPTION
See [here](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#_metamodel_changes_v3_1_vs_v3_0_2) for the change.