### PR TITLE
update data type lengths

### DIFF
--- a/sdk/basyx/aas/model/_string_constraints.py
+++ b/sdk/basyx/aas/model/_string_constraints.py
@@ -64,11 +64,11 @@ def check(value: str, type_name: str, min_length: int = 0, max_length: Optional[
 
 
 def check_content_type(value: str, type_name: str = "ContentType") -> None:
-    return check(value, type_name, 1, 100)
+    return check(value, type_name, 1, 128)
 
 
 def check_identifier(value: str, type_name: str = "Identifier") -> None:
-    return check(value, type_name, 1, 2000)
+    return check(value, type_name, 1, 2048)
 
 
 def check_label_type(value: str, type_name: str = "LabelType") -> None:
@@ -84,7 +84,7 @@ def check_name_type(value: str, type_name: str = "NameType") -> None:
 
 
 def check_path_type(value: str, type_name: str = "PathType") -> None:
-    return check(value, type_name, 1, 2000)
+    return check(value, type_name, 1, 2048)
 
 
 def check_qualifier_type(value: str, type_name: str = "QualifierType") -> None:
@@ -100,7 +100,7 @@ def check_short_name_type(value: str, type_name: str = "ShortNameType") -> None:
 
 
 def check_value_type_iec61360(value: str, type_name: str = "ValueTypeIEC61360") -> None:
-    return check(value, type_name, 1, 2000)
+    return check(value, type_name, 1, 2048)
 
 
 def check_version_type(value: str, type_name: str = "VersionType") -> None:

--- a/sdk/test/model/test_string_constraints.py
+++ b/sdk/test/model/test_string_constraints.py
@@ -17,11 +17,11 @@ class StringConstraintsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             _string_constraints.check_identifier(identifier)
         self.assertEqual("Identifier has a minimum length of 1! (length: 0)", cm.exception.args[0])
-        identifier = "a" * 2001
+        identifier = "a" * 2049
         with self.assertRaises(ValueError) as cm:
             _string_constraints.check_identifier(identifier)
-        self.assertEqual("Identifier has a maximum length of 2000! (length: 2001)", cm.exception.args[0])
-        identifier = "a" * 2000
+        self.assertEqual("Identifier has a maximum length of 2048! (length: 2049)", cm.exception.args[0])
+        identifier = "a" * 2048
         _string_constraints.check_identifier(identifier)
 
     def test_version_type(self) -> None:
@@ -73,8 +73,8 @@ class StringConstraintsDecoratorTest(unittest.TestCase):
         self.assertEqual("PathType has a minimum length of 1! (length: 0)", cm.exception.args[0])
         dc = self.DummyClass("a")
         with self.assertRaises(ValueError) as cm:
-            dc.some_attr = "a" * 2001
-        self.assertEqual("PathType has a maximum length of 2000! (length: 2001)", cm.exception.args[0])
+            dc.some_attr = "a" * 2049
+        self.assertEqual("PathType has a maximum length of 2048! (length: 2049)", cm.exception.args[0])
         self.assertEqual(dc.some_attr, "a")
 
     def test_ignore_none_values(self) -> None:


### PR DESCRIPTION
See [here](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/spec-metamodel/datatypes.html#primitive-data-types) for the length changes.