### PR TITLE
Update/metamodel v3.1.2: AASd-014

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -528,9 +528,12 @@ class AASFromJsonDecoder(json.JSONDecoder):
         if 'specificAssetIds' in dct:
             for desc_data in _get_ts(dct, "specificAssetIds", list):
                 specific_asset_id.add(cls._construct_specific_asset_id(desc_data, model.SpecificAssetId))
-
+        if 'entityType' in dct:
+            entity_type = ENTITY_TYPES_INVERSE[_get_ts(dct, 'entityType', str)]
+        else:
+            entity_type = None
         ret = object_class(id_short=None,
-                           entity_type=ENTITY_TYPES_INVERSE[_get_ts(dct, "entityType", str)],
+                           entity_type=entity_type,
                            global_asset_id=global_asset_id,
                            specific_asset_id=specific_asset_id)
         cls._amend_abstract_attributes(ret, dct)

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -827,10 +827,14 @@ class AASFromXmlDecoder:
             for id in _child_construct_multiple(specific_asset_ids, NS_AAS + "specificAssetId",
                                                 cls.construct_specific_asset_id, cls.failsafe):
                 specific_asset_id.add(id)
-
+        entity_type_text = _get_text_or_none(element.find(NS_AAS + "entityType"))
+        if entity_type_text is not None:
+            entity_type = ENTITY_TYPES_INVERSE[entity_type_text]
+        else:
+            entity_type = None
         entity = object_class(
             id_short=None,
-            entity_type=_child_text_mandatory_mapped(element, NS_AAS + "entityType", ENTITY_TYPES_INVERSE),
+            entity_type=entity_type,
             global_asset_id=_get_text_or_none(element.find(NS_AAS + "globalAssetId")),
             specific_asset_id=specific_asset_id)
 

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1063,8 +1063,8 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     """
     An entity is a :class:`~.SubmodelElement` that is used to model entities
 
-    **Constraint AASd-014:** global_asset_id or specific_asset_id must be set if ``entity_type`` is set to
-    :attr:`~basyx.aas.model.base.EntityType.SELF_MANAGED_ENTITY`. They must be empty otherwise.
+    **Constraint AASd-014:** Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` 
+    must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~basyx.aas.model.base.Referable`)

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1063,7 +1063,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     """
     An entity is a :class:`~.SubmodelElement` that is used to model entities
 
-    **Constraint AASd-014:** Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` 
+    **Constraint AASd-014:** Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity``
     must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1181,7 +1181,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
                            global_asset_id: Optional[base.Identifier],
                            specific_asset_id_nonempty: bool) -> None:
         if entity_type is None:
-            return
+            return 
         if entity_type == base.EntityType.SELF_MANAGED_ENTITY and global_asset_id is None \
                 and not specific_asset_id_nonempty:
             raise base.AASConstraintViolation(

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1181,7 +1181,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
                            global_asset_id: Optional[base.Identifier],
                            specific_asset_id_nonempty: bool) -> None:
         if entity_type is None:
-            return 
+            return
         if entity_type == base.EntityType.SELF_MANAGED_ENTITY and global_asset_id is None \
                 and not specific_asset_id_nonempty:
             raise base.AASConstraintViolation(

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -19,7 +19,7 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 .. |aasd006| replace:: If both, the ``value`` and the ``valueId`` of a ``Qualifier`` are present, the value needs to be identical to the value of the referenced coded value in ``Qualifier/valueId``.
 .. |aasd007| replace:: If both the ``Property/value`` and the ``Property/valueId`` are present, the value of ``Property/value`` needs to be identical to the value of the referenced coded value in ``Property/valueId``.
 .. |aasd012| replace:: if both the ``MultiLanguageProperty/value`` and the ``MultiLanguageProperty/valueId`` are present, the meaning must be the same for each string in a specific language, as specified in ``MultiLanguageProperty/valueId``.
-.. |aasd014| replace:: Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``. Otherwise, they do not exist.
+.. |aasd014| replace:: Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``.
 .. |aasd020| replace:: The value of ``Qualifier/value`` shall be consistent with the data type as defined in ``Qualifier/valueType``.
 .. |aasd021| replace:: Every qualifiable can only have one qualifier with the same ``Qualifier/type``.
 .. |aasd022| replace:: ``idShort`` of non-identifiable referables within the same name space shall be unique (case-sensitive).


### PR DESCRIPTION
AASd-014: `entityType` now optional. 
Update documentation and changed related code accordingly ([Changelog/AASd-014](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=CHANGED:%20Entity/entityType%20and%20Constraint%20AASd%2D014:%20entityType%20now%20optional%20(#287))).  