### PR TITLE
Update AASd-090

### DIFF
--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -150,13 +150,6 @@ class Submodel(base.Identifiable, base.HasSemantics, base.HasKind, base.Qualifia
         self.embedded_data_specifications: List[base.EmbeddedDataSpecification] = list(embedded_data_specifications)
 
 
-ALLOWED_DATA_ELEMENT_CATEGORIES: Set[str] = {
-    "CONSTANT",
-    "PARAMETER",
-    "VARIABLE"
-}
-
-
 class DataElement(SubmodelElement, metaclass=abc.ABCMeta):
     """
     A data element is a :class:`~.SubmodelElement` that is not further composed out of other
@@ -202,21 +195,6 @@ class DataElement(SubmodelElement, metaclass=abc.ABCMeta):
                  embedded_data_specifications: Iterable[base.EmbeddedDataSpecification] = ()):
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
-
-    def _set_category(self, category: Optional[str]):
-        if category == "":
-            raise base.AASConstraintViolation(100,
-                                              "category is not allowed to be an empty string")
-        if category is None:
-            self._category = None
-        else:
-            if category not in ALLOWED_DATA_ELEMENT_CATEGORIES:
-                if not (isinstance(self, File) or isinstance(self, Blob)):
-                    raise base.AASConstraintViolation(
-                        90,
-                        "DataElement.category must be one of the following: " +
-                        ", ".join(ALLOWED_DATA_ELEMENT_CATEGORIES))
-            self._category = category
 
 
 class Property(DataElement):

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -26,7 +26,6 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 .. |aasd077| replace:: The name of an extension (``Extension/name``) within ``HasExtensions`` needs to be unique.
 .. |aasd080| replace:: In case ``Key/type`` == ``GlobalReference`` ``idType`` shall not be any LocalKeyType (``IdShort, FragmentId``).
 .. |aasd081| replace:: In case ``Key/type`` == ``AssetAdministrationShell`` ``Key/idType`` shall not be any LocalKeyType (``IdShort``, ``FragmentId``).
-.. |aasd090| replace:: for data elements, ``category`` (inherited by ``Referable``) shall be one of the following values: CONSTANT, PARAMETER or VARIABLE. Default: VARIABLE
 .. |aasd107| replace:: If a first level child element in a ``SubmodelElementList`` has a semanticId, it shall be identical to ``SubmodelElementList/semanticIdListElement``.
 .. |aasd108| replace:: All first level child elements in a ``SubmodelElementList`` shall have the same submodel element type as specified in ``SubmodelElementList/typeValueListElement``.
 .. |aasd109| replace:: If ``SubmodelElementList/typeValueListElement`` is equal to ``Property`` or ``Range,`` ``SubmodelElementList/valueTypeListElement`` shall be set and all first level child elements in the ``SubmodelElementList`` shall have the value type as specified in ``SubmodelElementList/valueTypeListElement``.
@@ -76,7 +75,6 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
     AASd-077, |aasd077|, ✅,
     AASd-080, |aasd080|, ✅,
     AASd-081, |aasd081|, ✅,
-    AASd-090, |aasd090|, ✅,
     AASd-107, |aasd107|, ✅,
     AASd-108, |aasd108|, ✅,
     AASd-109, |aasd109|, ✅,


### PR DESCRIPTION
AASd-090: removed, since category is deprecated ([Changelog/AASd-090](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=REMOVED:%20remove%20AASd%2D090:%20category%20is%20deprecated%20(#514))).  