### PR TITLE
Removed AASd-120

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -819,9 +819,6 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
                 raise AASConstraintViolation(117, f"id_short of {self!r} cannot be unset, since it is already "
                                                   f"contained in {self.parent!r}")
             from .submodel import SubmodelElementList
-            if isinstance(self.parent, SubmodelElementList):
-                raise AASConstraintViolation(120, f"id_short of {self!r} cannot be set, because it is "
-                                                  f"contained in a {self.parent!r}")
             for set_ in self.parent.namespace_element_sets:
                 if set_.contains_id("id_short", id_short):
                     raise AASConstraintViolation(22, "Object with id_short '{}' is already present in the parent "

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -750,9 +750,6 @@ class SubmodelElementList(SubmodelElement, base.UniqueIdShortNamespace, Generic[
             raise
 
     def _generate_id_short(self, new: _SE) -> None:
-        if new.id_short is not None:
-            raise base.AASConstraintViolation(120, "Objects with an id_short may not be added to a "
-                                                   f"SubmodelElementList, got {new!r} with id_short={new.id_short}")
         # Generate a unique id_short when a SubmodelElement is added, because children of a SubmodelElementList may not
         # have an id_short. The alternative would be making SubmodelElementList a special kind of base.Namespace without
         # a unique attribute for child-elements (which contradicts the definition of a Namespace).

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -36,7 +36,6 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 .. |aasd117| replace:: ``idShort`` of non-identifiable ``Referables`` not being a direct child of a ``SubmodelElementList`` shall be specified.
 .. |aasd118| replace:: If a supplemental semantic ID (``HasSemantics/supplementalSemanticId``) is defined, there shall also be a main semantic ID (``HasSemantics/semanticId``).
 .. |aasd119| replace:: If any ``Qualifier/kind`` value of a ``Qualifiable/qualifier`` is equal to ``TemplateQualifier`` and the qualified element inherits from ``HasKind``, the qualified element shall be of kind ``Template`` (``HasKind/kind = Template``).
-.. |aasd120| replace:: ``idShort`` of submodel elements being a direct child of a ``SubmodelElementList`` shall not be specified.
 .. |aasd121| replace:: For ``References``, the value of ``Key/type`` of the first ``key`` of ``Reference/keys`` shall be one of ``GloballyIdentifiables``.
 .. |aasd122| replace:: For external references, i.e. ``References`` with ``Reference/type = ExternalReference``, the value of ``Key/type`` of the first key of ``Reference/keys`` shall be one of ``GenericGloballyIdentifiables``.
 .. |aasd123| replace:: For model references, i.e. ``References`` with ``Reference/type = ModellReference``, the value of ``Key/type`` of the first ``key`` of ``Reference/keys`` shall be one of ``AasIdentifiables``.
@@ -86,7 +85,6 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
     AASd-117, |aasd117|, ✅,
     AASd-118, |aasd118|, ✅,
     AASd-119, |aasd119|, ❌, See `#119 <https://github.com/eclipse-basyx/basyx-python-sdk/issues/119>`__
-    AASd-120, |aasd120|, ✅,
     AASd-121, |aasd121|, ✅,
     AASd-122, |aasd122|, ✅,
     AASd-123, |aasd123|, ✅,

--- a/sdk/test/model/test_submodel.py
+++ b/sdk/test/model/test_submodel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_submodel.py
+++ b/sdk/test/model/test_submodel.py
@@ -232,19 +232,6 @@ class SubmodelElementListTest(unittest.TestCase):
         mlp2.semantic_id = semantic_id1
         model.SubmodelElementList("test_list", model.MultiLanguageProperty, [mlp1, mlp2])
 
-        # AASd-120
-        mlp = model.MultiLanguageProperty("mlp")
-        with self.assertRaises(model.AASConstraintViolation) as cm:
-            model.SubmodelElementList("test_list", model.MultiLanguageProperty, [mlp])
-        self.assertEqual("Objects with an id_short may not be added to a SubmodelElementList, got "
-                         "MultiLanguageProperty[mlp] with id_short=mlp (Constraint AASd-120)", str(cm.exception))
-        mlp.id_short = None
-        model.SubmodelElementList("test_list", model.MultiLanguageProperty, [mlp])
-        with self.assertRaises(model.AASConstraintViolation) as cm:
-            mlp.id_short = "mlp"
-        self.assertEqual("id_short of MultiLanguageProperty[test_list[0]] cannot be set, because it is "
-                         "contained in a SubmodelElementList[test_list] (Constraint AASd-120)", str(cm.exception))
-
     def test_aasd_108_add_set(self):
         prop = model.Property(None, model.datatypes.Int)
         mlp1 = model.MultiLanguageProperty(None)


### PR DESCRIPTION
Removed AASd-120 and related code to AASd-120 ([Changelog/AASd-120](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D120,-Removed)).