### PR TITLE
Update/metamodel v3.1.2 add role to asset kind

### DIFF
--- a/sdk/basyx/aas/adapter/_generic.py
+++ b/sdk/basyx/aas/adapter/_generic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/adapter/_generic.py
+++ b/sdk/basyx/aas/adapter/_generic.py
@@ -37,7 +37,8 @@ MODELLING_KIND: Dict[model.ModellingKind, str] = {
 ASSET_KIND: Dict[model.AssetKind, str] = {
     model.AssetKind.TYPE: 'Type',
     model.AssetKind.INSTANCE: 'Instance',
-    model.AssetKind.NOT_APPLICABLE: 'NotApplicable'}
+    model.AssetKind.NOT_APPLICABLE: 'NotApplicable',
+    model.AssetKind.ROLE: 'Role'}
 
 QUALIFIER_KIND: Dict[model.QualifierKind, str] = {
     model.QualifierKind.CONCEPT_QUALIFIER: 'ConceptQualifier',

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -241,8 +241,8 @@ class AssetKind(Enum):
 
     TYPE = 0
     INSTANCE = 1
-    ROLE = 2
-    NOT_APPLICABLE = 3
+    NOT_APPLICABLE = 2
+    ROLE = 3
 
 
 class QualifierKind(Enum):


### PR DESCRIPTION
New value `role` to asset kind according to ([Changelog/AssetKind](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AssetKind/Role,-New%20value%20in)).  