### PR TITLE
Update/metamodell v3.1.2 update constr docs

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1640,7 +1640,7 @@ class Qualifier(HasSemantics):
     """
     A qualifier is a type-value pair that makes additional statements w.r.t. the value of the element.
 
-    **Constraint AASd-006:** If both, the value and the valueId of a Qualifier are present, the value shall 
+    **Constraint AASd-006:** If both, the value and the valueId of a Qualifier are present, the value shall
     be identical to the value of the referenced coded value in Qualifier/valueId.
 
     **Constraint AASd-020:** The value of Qualifier/value shall be consistent with the

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -551,7 +551,7 @@ class HasExtension(Namespace, metaclass=abc.ABCMeta):
 
     <<abstract>>
 
-    **Constraint AASd-077:** The name of an Extension within HasExtensions needs to be unique.
+    **Constraint AASd-077:** The name of an Extension within HasExtensions shall be unique.
 
     :ivar namespace_element_sets: List of :class:`NamespaceSets <basyx.aas.model.base.NamespaceSet>`
     :ivar extension: A :class:`~.NamespaceSet` of :class:`Extensions <.Extension>` of the element.
@@ -1640,8 +1640,8 @@ class Qualifier(HasSemantics):
     """
     A qualifier is a type-value pair that makes additional statements w.r.t. the value of the element.
 
-    **Constraint AASd-006:** If both, the value and the valueId of a Qualifier are present, the value needs
-    to be identical to the value of the referenced coded value in Qualifier/valueId.
+    **Constraint AASd-006:** If both, the value and the valueId of a Qualifier are present, the value shall 
+    be identical to the value of the referenced coded value in Qualifier/valueId.
 
     **Constraint AASd-020:** The value of Qualifier/value shall be consistent with the
     data type as defined in Qualifier/valueType.

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -224,7 +224,7 @@ class Property(DataElement):
     A property is a :class:`DataElement` that has a single value.
 
     **Constraint AASd-007:** If both, the value and the valueId of a Qualifier are present,
-    the value needs to be identical to the value of the referenced coded value in Qualifier/valueId.
+    the value shall be identical to the value of the referenced coded value in Qualifier/valueId.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~basyx.aas.model.base.Referable`)

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -16,14 +16,14 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 
 .. |aasd002| replace:: ``idShort`` of ``Referable`` s shall only feature letters, digits, underscore (``_``), hyphen (``-``); starting mandatory with a letter and not ending with a hyphen. I.e. ``^[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_-]*[a-zA-Z0-9_]$``.
 .. |aasd005| replace:: If ``AdministrativeInformation/version`` is not specified, ``AdministrativeInformation/revision`` shall also be unspecified. This means that a revision requires a version. If there is no version, there is no revision. Revision is optional.
-.. |aasd006| replace:: If both, the ``value`` and the ``valueId`` of a ``Qualifier`` are present, the value needs to be identical to the value of the referenced coded value in ``Qualifier/valueId``.
-.. |aasd007| replace:: If both the ``Property/value`` and the ``Property/valueId`` are present, the value of ``Property/value`` needs to be identical to the value of the referenced coded value in ``Property/valueId``.
+.. |aasd006| replace:: If both, the ``value`` and the ``valueId`` of a ``Qualifier`` are present, the value shall be identical to the value of the referenced coded value in ``Qualifier/valueId``.
+.. |aasd007| replace:: If both the ``Property/value`` and the ``Property/valueId`` are present, the value of ``Property/value`` shall be identical to the value of the referenced coded value in ``Property/valueId``.
 .. |aasd012| replace:: if both the ``MultiLanguageProperty/value`` and the ``MultiLanguageProperty/valueId`` are present, the meaning must be the same for each string in a specific language, as specified in ``MultiLanguageProperty/valueId``.
 .. |aasd014| replace:: Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``. Otherwise, they do not exist.
 .. |aasd020| replace:: The value of ``Qualifier/value`` shall be consistent with the data type as defined in ``Qualifier/valueType``.
 .. |aasd021| replace:: Every qualifiable can only have one qualifier with the same ``Qualifier/type``.
 .. |aasd022| replace:: ``idShort`` of non-identifiable referables within the same name space shall be unique (case-sensitive).
-.. |aasd077| replace:: The name of an extension (``Extension/name``) within ``HasExtensions`` needs to be unique.
+.. |aasd077| replace:: The name of an extension (``Extension/name``) within ``HasExtensions`` shall be unique.
 .. |aasd080| replace:: In case ``Key/type`` == ``GlobalReference`` ``idType`` shall not be any LocalKeyType (``IdShort, FragmentId``).
 .. |aasd081| replace:: In case ``Key/type`` == ``AssetAdministrationShell`` ``Key/idType`` shall not be any LocalKeyType (``IdShort``, ``FragmentId``).
 .. |aasd090| replace:: for data elements, ``category`` (inherited by ``Referable``) shall be one of the following values: CONSTANT, PARAMETER or VARIABLE. Default: VARIABLE

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -32,7 +32,7 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 .. |aasd109| replace:: If ``SubmodelElementList/typeValueListElement`` is equal to ``Property`` or ``Range,`` ``SubmodelElementList/valueTypeListElement`` shall be set and all first level child elements in the ``SubmodelElementList`` shall have the value type as specified in ``SubmodelElementList/valueTypeListElement``.
 .. |aasd114| replace:: If two first level child elements in a ``SubmodelElementList`` have a ``semanticId``, they shall be identical.
 .. |aasd115| replace:: If a first level child element in a ``SubmodelElementList`` does not specify a ``semanticId``, the value is assumed to be identical to ``SubmodelElementList/semanticIdListElement``.
-.. |aasd116| replace:: ``globalAssetId`` (case-insensitive) is a reserved key. If used as value for ``SpecificAssetId/name,`` ``SpecificAssetId/value`` shall be identical to ``AssetInformation/globalAssetId``.
+.. |aasd116| replace:: ``globalAssetId`` (case-insensitive) is a reserved key for ``SpecificAssetId/name`` with the semantics as defined in ``:attr:`basyx.aas.model.aas.AssetInformation.global_asset_id``.
 .. |aasd117| replace:: ``idShort`` of non-identifiable ``Referables`` not being a direct child of a ``SubmodelElementList`` shall be specified.
 .. |aasd118| replace:: If a supplemental semantic ID (``HasSemantics/supplementalSemanticId``) is defined, there shall also be a main semantic ID (``HasSemantics/semanticId``).
 .. |aasd119| replace:: If any ``Qualifier/kind`` value of a ``Qualifiable/qualifier`` is equal to ``TemplateQualifier`` and the qualified element inherits from ``HasKind``, the qualified element shall be of kind ``Template`` (``HasKind/kind = Template``).

--- a/sdk/docs/source/constraints.rst
+++ b/sdk/docs/source/constraints.rst
@@ -21,7 +21,7 @@ an :class:`~basyx.aas.model.base.AASConstraintViolation` will be raised
 .. |aasd012| replace:: if both the ``MultiLanguageProperty/value`` and the ``MultiLanguageProperty/valueId`` are present, the meaning must be the same for each string in a specific language, as specified in ``MultiLanguageProperty/valueId``.
 .. |aasd014| replace:: Either the attribute ``globalAssetId`` or ``specificAssetId`` of an ``Entity`` must be set if ``Entity/entityType`` is set to ``SelfManagedEntity``. Otherwise, they do not exist.
 .. |aasd020| replace:: The value of ``Qualifier/value`` shall be consistent with the data type as defined in ``Qualifier/valueType``.
-.. |aasd021| replace:: Every qualifiable can only have one qualifier with the same ``Qualifier/type``.
+.. |aasd021| replace:: Every qualifiable shall only have one qualifier with the same ``Qualifier/type``.
 .. |aasd022| replace:: ``idShort`` of non-identifiable referables within the same name space shall be unique (case-sensitive).
 .. |aasd077| replace:: The name of an extension (``Extension/name``) within ``HasExtensions`` shall be unique.
 .. |aasd080| replace:: In case ``Key/type`` == ``GlobalReference`` ``idType`` shall not be any LocalKeyType (``IdShort, FragmentId``).


### PR DESCRIPTION
Replace "needs to" with "shall" ([AASd-006](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D006,-Update), [AASd-007](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D007,-Update), [AASd-021](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D021,-Update), [AASd-077](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D077,-Update)) in Docstrings. 

Update documentation for [AASd-116](https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/changelog.html#:~:text=AASd%2D116,-Update). 