### PR TITLE
CI: Temporarily disable compliance-tool tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,36 +203,37 @@ jobs:
         chmod +x ./etc/scripts/set_copyright_year.sh
         ./etc/scripts/set_copyright_year.sh --check
 
+# Todo: reset when the compliance-tool was updated (#485)
 
-  compliance-tool-test:
-    # This job runs the unittests on the python versions specified down at the matrix
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.12"]
-    defaults:
-      run:
-        working-directory: ./compliance_tool
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Python dependencies
-      # install the local sdk in editable mode so it does not get overwritten
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ../sdk
-        python -m pip install .[dev]
-    - name: Test with coverage + unittest
-      run: |
-        python -m coverage run --source=aas_compliance_tool -m unittest
-    - name: Report test coverage
-      if: ${{ always() }}
-      run: |
-        python -m coverage report -m
+#  compliance-tool-test:
+#    # This job runs the unittests on the python versions specified down at the matrix
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        python-version: ["3.10", "3.12"]
+#    defaults:
+#      run:
+#        working-directory: ./compliance_tool
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set up Python ${{ matrix.python-version }}
+#      uses: actions/setup-python@v5
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#    - name: Install Python dependencies
+#      # install the local sdk in editable mode so it does not get overwritten
+#      run: |
+#        python -m pip install --upgrade pip
+#        python -m pip install ../sdk
+#        python -m pip install .[dev]
+#    - name: Test with coverage + unittest
+#      run: |
+#        python -m coverage run --source=aas_compliance_tool -m unittest
+#    - name: Report test coverage
+#      if: ${{ always() }}
+#      run: |
+#        python -m coverage report -m
 
   compliance-tool-static-analysis:
     # This job runs static code analysis, namely pycodestyle and mypy


### PR DESCRIPTION
Until we implement https://github.com/eclipse-basyx/basyx-python-sdk/issues/485 and update the `compliance-tool` properly, we should exclude it from the CI tests.